### PR TITLE
feat: add programmatic API for importing and using library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ CLI tool to visualise CloudFormation/SAM/CDK templates as diagrams.
 `npm i -g @mhlabs/cfn-diagram`
 
 ## Usage
+
+### Command Line Interface
 ```
 Usage: cfn-dia [options] [command]
 
@@ -18,6 +20,8 @@ Commands:
   draw.io|d [options]                 Generates a draw.io diagram from a CloudFormation template
   html|h [options]                    Generates a vis.js diagram from a CloudFormation template
   browse|b [options]                  Browses and generates diagrams from your deployed templates
+  ascii-art|a [options]               Generates an ascii-art diagram from a CloudFormation template
+  mermaid|m [options]                 Generates a mermaid graph from a template
   help [command]                      Display help for command
 
 Draw.io Options:
@@ -35,6 +39,39 @@ Html Options:
   -co, --cdk-output [outputPath]      CDK synth output path
   -s, --skip-synth                    Skips CDK synth
 ```
+
+### Programmatic Usage
+You can also use cfn-diagram as an imported module in your Node.js applications:
+
+```javascript
+const cfnDiagram = require('@mhlabs/cfn-diagram');
+
+// Example: Render a CloudFormation template as ASCII art
+async function renderTemplate() {
+  const asciiOutput = await cfnDiagram.renderers.asciiArt.render('path/to/template.yaml', {
+    returnBuffer: true,  // Return the ASCII art as a string
+    border: true,        // Add a border with stack name
+    ci: true             // CI mode (no cursor control)
+  });
+  
+  console.log(asciiOutput);
+}
+
+// Example: Get raw XML representation
+async function getRawXml() {
+  const xmlOutput = await cfnDiagram.renderTemplate('path/to/template.yaml');
+  console.log(`XML generated (length: ${xmlOutput.length} characters)`);
+}
+```
+
+The main module exports:
+
+- `renderTemplate(templatePath, options)` - Core rendering function that returns XML representation
+- `renderers.asciiArt.render(templatePath, options)` - Renders template as ASCII art
+- `renderers.drawio`, `renderers.html`, `renderers.mermaid` - Other renderers (to be implemented)
+- `utils.templateParser` and `utils.mxGenerator` - Lower-level utilities
+
+See the [examples directory](./examples/programmatic-usage.js) for more detailed examples.
 
 ## Output formats
 

--- a/examples/programmatic-usage.js
+++ b/examples/programmatic-usage.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const path = require('path');
+const cfnDiagram = require('../index');
+
+async function main() {
+  try {
+    console.log("Example 1: Basic rendering of CloudFormation template as ASCII art");
+    
+    // Path to your template file
+    const templatePath = path.join(__dirname, '../tests/resources/simple-template.yaml');
+    
+    // Render template as ASCII art and capture output as string
+    const asciiOutput = await cfnDiagram.renderers.asciiArt.render(templatePath, {
+      returnBuffer: true,   // Return the ASCII art as a string instead of printing to console
+      border: true,         // Add a border with stack name
+      ci: true              // CI mode (no cursor control, full output at once)
+    });
+    
+    console.log("\nASCII Art Output:");
+    console.log(asciiOutput);
+    
+    // Example 2: Get raw XML representation
+    console.log("\nExample 2: Get raw XML representation of the CloudFormation template");
+    const xmlOutput = await cfnDiagram.renderTemplate(templatePath);
+    console.log(`XML generated (length: ${xmlOutput.length} characters)`);
+    // console.log(xmlOutput); // Uncomment to see the full XML
+    
+    // Example 3: Generate a draw.io diagram
+    console.log("\nExample 3: Generate a draw.io diagram file");
+    const outputPath = '/tmp/cfn-diagram-example.drawio';
+    const drawioFile = await cfnDiagram.renderers.drawio.render(templatePath, outputPath, {
+      ciMode: true,
+      excludeTypes: ['AWS::IAM::Role'] // Example of excluding a specific resource type
+    });
+    console.log(`Draw.io diagram generated at: ${drawioFile}`);
+    
+    console.log("\nExamples completed successfully!");
+  } catch (error) {
+    console.error("Error running examples:", error);
+  }
+}
+
+// Run the examples
+main();

--- a/index.js
+++ b/index.js
@@ -1,10 +1,174 @@
 #!/usr/bin/env node
 const program = require("commander");
+const mxGenerator = require("./graph/MxGenerator");
+const templateParser = require("./shared/templateParser");
+const mxGraphToAsciiArt = require("./commands/asciiart/mxgraph-to-asciiart");
+const filterConfig = require("./resources/FilterConfig");
+const packag = require("./package.json");
+
+// Load all command modules
 require("./commands/draw.io");
 require("./commands/html");
 require("./commands/asciiart");
 require("./commands/browse");
 require("./commands/mermaid");
-const packag = require("./package.json");
+
+// Set up CLI version
 program.version(packag.version, "-v, --vers", "output the current version");
-program.parse(process.argv);
+
+// When run directly as a script, parse command line arguments
+if (require.main === module) {
+  program.parse(process.argv);
+}
+
+// Module exports for programmatic usage
+module.exports = {
+  // Core functionality
+  renderTemplate: async (templatePath, options = {}) => {
+    const cmd = {
+      templateFile: templatePath,
+      cdkOutput: options.cdkOutput || 'cdk.out',
+      skipSynth: options.skipSynth !== undefined ? options.skipSynth : true,
+      stacks: options.stacks || null
+    };
+    const template = templateParser.get(cmd).template;
+    
+    // Set up filterConfig
+    if (!template.Resources) {
+      throw new Error("Can't find resources in " + templatePath);
+    }
+    
+    // Initialize filter config with all resources
+    const resourceNames = Object.keys(template.Resources);
+    const resourceTypes = resourceNames.map(name => template.Resources[name].Type);
+    
+    filterConfig.resourceNamesToInclude = resourceNames;
+    filterConfig.resourceTypesToInclude = resourceTypes;
+    filterConfig.edgeMode = "On";
+    
+    return await mxGenerator.renderTemplate(template);
+  },
+  
+  // Main renderers
+  renderers: {
+    asciiArt: {
+      render: async (templatePath, options = {}) => {
+        const cmd = {
+          templateFile: templatePath,
+          cdkOutput: options.cdkOutput || 'cdk.out',
+          skipSynth: options.skipSynth !== undefined ? options.skipSynth : true,
+          stacks: options.stacks || null,
+          ci: options.ci !== undefined ? options.ci : true,
+          border: options.border !== undefined ? options.border : false
+        };
+        const template = templateParser.get(cmd).template;
+        if (!template.Resources) {
+          throw new Error("Can't find resources in " + templatePath);
+        }
+        
+        // Initialize filter config with all resources
+        const resourceNames = Object.keys(template.Resources);
+        const resourceTypes = resourceNames.map(name => template.Resources[name].Type);
+        
+        filterConfig.resourceNamesToInclude = resourceNames;
+        filterConfig.resourceTypesToInclude = resourceTypes;
+        filterConfig.edgeMode = "On";
+        
+        mxGenerator.reset();
+        const xml = await mxGenerator.renderTemplate(template);
+        const stackName = templateParser.getStackName(template);
+        
+        if (options.returnBuffer) {
+          // Return the ascii buffer without printing
+          const buffer = new mxGraphToAsciiArt.AsciiBuffer();
+          mxGraphToAsciiArt.render(xml, { 
+            ci: true,
+            border: cmd.border,
+            stackName: stackName,
+            buffer: buffer,
+            skipOutput: true
+          });
+          return buffer.toString();
+        } else {
+          // Print to console and return the XML
+          mxGraphToAsciiArt.render(xml, { 
+            ci: cmd.ci,
+            border: cmd.border,
+            stackName: stackName
+          });
+          return xml;
+        }
+      }
+    },
+    
+    // Other renderers can be added here
+    drawio: {
+      render: async (templatePath, outputFile = 'template.drawio', options = {}) => {
+        const cmd = {
+          templateFile: templatePath,
+          outputFile: outputFile,
+          cdkOutput: options.cdkOutput || 'cdk.out',
+          skipSynth: options.skipSynth !== undefined ? options.skipSynth : true,
+          stacks: options.stacks || null,
+          ciMode: options.ciMode !== undefined ? options.ciMode : true,
+          excludeTypes: options.excludeTypes || []
+        };
+        
+        // Initialize filter config
+        const template = templateParser.get(cmd).template;
+        if (!template.Resources) {
+          throw new Error("Can't find resources in " + templatePath);
+        }
+        
+        // Initialize filter config with all resources
+        const resourceNames = Object.keys(template.Resources);
+        const resourceTypes = resourceNames.map(name => template.Resources[name].Type);
+        
+        filterConfig.resourceNamesToInclude = resourceNames;
+        filterConfig.resourceTypesToInclude = resourceTypes;
+        filterConfig.edgeMode = "On";
+        
+        // Apply exclusions if specified
+        if (cmd.excludeTypes && cmd.excludeTypes.length > 0) {
+          filterConfig.resourceTypesToInclude = filterConfig.resourceTypesToInclude.filter(
+            type => !cmd.excludeTypes.includes(type)
+          );
+        }
+        
+        // Generate the XML
+        mxGenerator.reset();
+        const xml = await mxGenerator.renderTemplate(template);
+        
+        // Save to file
+        const fs = require('fs');
+        fs.writeFileSync(outputFile, xml);
+        
+        return outputFile;
+      }
+    },
+    
+    html: {
+      render: (templatePath, options = {}) => {
+        // Import the required module
+        const html = require("./commands/html");
+        // Implementation would go here
+        throw new Error("Programmatic HTML rendering not yet implemented");
+      }
+    },
+    
+    mermaid: {
+      render: (templatePath, options = {}) => {
+        // Import the required module
+        const mermaid = require("./commands/mermaid");
+        // Implementation would go here
+        throw new Error("Programmatic mermaid rendering not yet implemented");
+      }
+    }
+  },
+  
+  // Utility exports
+  utils: {
+    templateParser,
+    mxGenerator
+  }
+};

--- a/test-programmatic-usage.sh
+++ b/test-programmatic-usage.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Test programmatic usage of the library
+
+echo "Running programmatic usage example..."
+node examples/programmatic-usage.js 
+
+# Check if the drawio file was created
+if [ -f /tmp/cfn-diagram-example.drawio ]; then
+    echo -e "\nVerifying drawio file..."
+    file_size=$(stat -f%z "/tmp/cfn-diagram-example.drawio")
+    echo "File size: $file_size bytes"
+    
+    if [ "$file_size" -gt 500 ]; then
+        echo "✅ Draw.io file generated successfully"
+    else
+        echo "❌ Draw.io file seems invalid (too small)"
+        exit 1
+    fi
+else
+    echo "❌ Draw.io file not found at /tmp/cfn-diagram-example.drawio"
+    exit 1
+fi
+
+echo -e "\n✅ All tests passed!"


### PR DESCRIPTION
## Summary
- Refactor index.js to expose the library's functionality as a module
- Add module.exports to make key functions available for programmatic use
- Create example file showing how to use the library in Node.js applications
- Update README with documentation on programmatic usage patterns
- Implement basic programmatic access for ASCII art and draw.io renderers
- Add test script to verify programmatic functionality

## Test plan
- Run test-programmatic-usage.sh to verify functionality
- Import library in a Node.js script and render templates
- Verify ASCII art and draw.io outputs match CLI results

🤖 Generated with [Claude Code](https://claude.ai/code)